### PR TITLE
Websocket init for event broadcasting across chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ A blockchain where AI validators with unique personalities engage in chaotic con
    ```
 
 # Start bootstrap node
-go run cmd/main.go -port 8080 -api 3000 -bootstrap localhost:8080
+go run cmd/main.go -port 8080 -api 3000 -bootstrap localhost:8080 -nats nats://localhost:4222

--- a/api/handlers/handlers.go
+++ b/api/handlers/handlers.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/NethermindEth/chaoschain-launchpad/ai"
 	"github.com/NethermindEth/chaoschain-launchpad/cmd/node"
+	"github.com/NethermindEth/chaoschain-launchpad/communication"
 	"github.com/NethermindEth/chaoschain-launchpad/consensus"
 	"github.com/NethermindEth/chaoschain-launchpad/core"
 	"github.com/NethermindEth/chaoschain-launchpad/mempool"
@@ -19,7 +20,6 @@ import (
 	"github.com/NethermindEth/chaoschain-launchpad/producer"
 	"github.com/NethermindEth/chaoschain-launchpad/registry"
 	"github.com/NethermindEth/chaoschain-launchpad/validator"
-	"github.com/NethermindEth/chaoschain-launchpad/forum"
 )
 
 var (
@@ -269,7 +269,7 @@ func ProposeBlock(c *gin.Context) {
 	threadID := block.Hash()
 	producerName := "ProducerAgent" // Replace with the actual producer agent's name as needed.
 	title := fmt.Sprintf("Block Proposal %s", threadID)
-	forum.CreateThread(threadID, title, producerName)
+	communication.CreateThread(threadID, title, producerName)
 
 	cm := consensus.GetConsensusManager()
 	if err := cm.ProposeBlock(block); err != nil {
@@ -310,6 +310,6 @@ func ProposeBlock(c *gin.Context) {
 
 // GetAllThreads returns all active discussion threads for monitoring.
 func GetAllThreads(c *gin.Context) {
-	threads := forum.GetAllThreads() // We'll implement this function in forum
+	threads := communication.GetAllThreads() // We'll implement this function in forum
 	c.JSON(http.StatusOK, threads)
 }

--- a/api/handlers/websocket.go
+++ b/api/handlers/websocket.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/NethermindEth/chaoschain-launchpad/communication"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool {
+		return true // Allow all origins in development
+	},
+}
+
+func HandleWebSocket(c *gin.Context) {
+	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		log.Printf("Failed to upgrade connection: %v", err)
+		return
+	}
+
+	// Register client
+	wsManager := communication.GetWSManager()
+	wsManager.Register() <- conn
+
+	// Handle disconnection
+	go func() {
+		<-c.Done()
+		wsManager.Unregister() <- conn
+	}()
+}

--- a/api/routes.go
+++ b/api/routes.go
@@ -20,4 +20,7 @@ func SetupRoutes(router *gin.Engine) {
 		api.POST("/block/propose", handlers.ProposeBlock)
 		api.GET("/forum/threads", handlers.GetAllThreads)
 	}
+
+	// WebSocket endpoint
+	router.GET("/ws", handlers.HandleWebSocket)
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/NethermindEth/chaoschain-launchpad/core"
 	"github.com/NethermindEth/chaoschain-launchpad/api"
 	"github.com/NethermindEth/chaoschain-launchpad/cmd/node"
 	_ "github.com/NethermindEth/chaoschain-launchpad/config" // Initialize config
+	"github.com/NethermindEth/chaoschain-launchpad/core"
 	"github.com/gin-gonic/gin"
 )
 
@@ -17,6 +17,7 @@ func main() {
 	port := flag.Int("port", 8080, "P2P port")
 	apiPort := flag.Int("api", 3000, "API port")
 	bootstrapNode := flag.String("bootstrap", "", "Bootstrap node address")
+	nats := flag.String("nats", "nats://localhost:4222", "NATS URL")
 	flag.Parse()
 
 	// Create and start node
@@ -31,8 +32,10 @@ func main() {
 	}
 
 	// Start NATS messaging
-	core.SetupNATS("nats://localhost:4222")
-	defer core.NatsBrokerInstance.Close()
+	if *nats != "" {
+		core.SetupNATS(*nats)
+		defer core.NatsBrokerInstance.Close()
+	}
 
 	log.Println("Application started with NATS messaging enabled.")
 

--- a/communication/acl_agent.go
+++ b/communication/acl_agent.go
@@ -1,13 +1,13 @@
-package acl
+package communication
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
-	"github.com/google/uuid"
 	"io"
 	"net"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // FIPAMessage defines a standard FIPA ACL message.

--- a/communication/forum.go
+++ b/communication/forum.go
@@ -1,4 +1,4 @@
-package forum
+package communication
 
 import (
 	"fmt"
@@ -18,7 +18,7 @@ type ForumMessage struct {
 
 // ForumThread represents a discussion thread for a block proposal.
 type ForumThread struct {
-	ThreadID  string         `json:"thread_id"`  // e.g., the block hash
+	ThreadID  string         `json:"thread_id"` // e.g., the block hash
 	Title     string         `json:"title"`
 	Creator   string         `json:"creator"`
 	CreatedAt time.Time      `json:"created_at"`
@@ -88,4 +88,4 @@ func GetAllThreads() []*ForumThread {
 		threadsList = append(threadsList, thread)
 	}
 	return threadsList
-} 
+}

--- a/communication/nats_messaging.go
+++ b/communication/nats_messaging.go
@@ -1,7 +1,8 @@
-package messaging
+package communication
 
 import (
 	"fmt"
+
 	"github.com/nats-io/nats.go"
 )
 

--- a/communication/websocket.go
+++ b/communication/websocket.go
@@ -1,0 +1,94 @@
+package communication
+
+import (
+	"log"
+	"sync"
+
+	"github.com/gorilla/websocket"
+)
+
+type WSEvent struct {
+	Type    string      `json:"type"`
+	Payload interface{} `json:"payload"`
+}
+
+const (
+	EventBlockVerdict    = "BLOCK_VERDICT"
+	EventAgentVote       = "AGENT_VOTE"
+	EventVotingResult    = "VOTING_RESULT"
+	EventAgentAlliance   = "AGENT_ALLIANCE"
+	EventAgentRegistered = "AGENT_REGISTERED"
+	EventNewTransaction  = "NEW_TRANSACTION"
+)
+
+type WebSocketManager struct {
+	clients    map[*websocket.Conn]bool
+	broadcast  chan WSEvent
+	register   chan *websocket.Conn
+	unregister chan *websocket.Conn
+	mu         sync.RWMutex
+}
+
+var (
+	wsManager *WebSocketManager
+	once      sync.Once
+)
+
+func GetWSManager() *WebSocketManager {
+	once.Do(func() {
+		wsManager = &WebSocketManager{
+			clients:    make(map[*websocket.Conn]bool),
+			broadcast:  make(chan WSEvent),
+			register:   make(chan *websocket.Conn),
+			unregister: make(chan *websocket.Conn),
+		}
+		go wsManager.run()
+	})
+	return wsManager
+}
+
+func (manager *WebSocketManager) run() {
+	for {
+		select {
+		case client := <-manager.register:
+			manager.mu.Lock()
+			manager.clients[client] = true
+			manager.mu.Unlock()
+
+		case client := <-manager.unregister:
+			manager.mu.Lock()
+			if _, ok := manager.clients[client]; ok {
+				delete(manager.clients, client)
+				client.Close()
+			}
+			manager.mu.Unlock()
+
+		case event := <-manager.broadcast:
+			manager.mu.RLock()
+			for client := range manager.clients {
+				if err := client.WriteJSON(event); err != nil {
+					log.Printf("WebSocket error: %v", err)
+					client.Close()
+					delete(manager.clients, client)
+				}
+			}
+			manager.mu.RUnlock()
+		}
+	}
+}
+
+func BroadcastEvent(eventType string, payload interface{}) {
+	event := WSEvent{
+		Type:    eventType,
+		Payload: payload,
+	}
+	GetWSManager().broadcast <- event
+}
+
+func (w *WebSocketManager) Register() chan<- *websocket.Conn {
+	return w.register
+}
+
+func (w *WebSocketManager) Unregister() chan<- *websocket.Conn {
+	return w.unregister
+}

--- a/consensus/discussion.go
+++ b/consensus/discussion.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"github.com/NethermindEth/chaoschain-launchpad/ai"
+	"github.com/NethermindEth/chaoschain-launchpad/communication"
 	"github.com/NethermindEth/chaoschain-launchpad/core"
 	"github.com/NethermindEth/chaoschain-launchpad/p2p"
-	"github.com/NethermindEth/chaoschain-launchpad/forum"
 )
 
 type Discussion struct {
@@ -107,12 +107,11 @@ func StartBlockDiscussion(validatorID string, block *core.Block, traits []string
 	// Add to discussion
 	consensus.AddDiscussion(validatorID, response, opinionType)
 
-
 	threadID := block.Hash()
 	sanitizedValidatorID := strings.ReplaceAll(validatorID, "\n", "")
 	sanitizedValidatorID = strings.ReplaceAll(sanitizedValidatorID, "\r", "")
 	log.Printf("Added reply from %s to thread %s: %s", sanitizedValidatorID, threadID, response)
-	if err := forum.AddReply(threadID, validatorID, response); err != nil {
+	if err := communication.AddReply(threadID, validatorID, response); err != nil {
 		log.Printf("Validator %s failed to add forum reply: %v", name, err)
 	}
 }

--- a/consensus/discussion.go
+++ b/consensus/discussion.go
@@ -106,6 +106,12 @@ func StartBlockDiscussion(validatorID string, block *core.Block, traits []string
 
 	// Add to discussion
 	consensus.AddDiscussion(validatorID, response, opinionType)
+	communication.BroadcastEvent(communication.EventAgentVote, Discussion{
+		ValidatorID: validatorID,
+		Message:     response,
+		Type:        opinionType,
+		Timestamp:   time.Now(),
+	})
 
 	threadID := block.Hash()
 	sanitizedValidatorID := strings.ReplaceAll(validatorID, "\n", "")

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,13 @@ go 1.24.0
 require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.3
+	github.com/nats-io/nats.go v1.39.1
 	github.com/sashabaranov/go-openai v1.38.0
 )
 
 require (
 	github.com/klauspost/compress v1.17.9 // indirect
-	github.com/nats-io/nats.go v1.39.1 // indirect
 	github.com/nats-io/nkeys v0.4.9 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=


### PR DESCRIPTION
Closes #13 

Make websocket connections accessible at `/ws`

Events broadcasted as:

1. "BLOCK_VERDICT" → Broadcast the consensus verdict for a block
2. "AGENT_VOTE" → Broadcast the individual votes of each agent
3. "VOTING_RESULT" → Shows the statistics of oppose/question/reject from agents after a consensus cycle
4. "AGENT_ALLIANCE" → Broadcast any created alliance between agents
5. "AGENT_REGISTERED" → Broadcast whenever a new agent nodes joins the chain
6. "NEW_TRANSACTION" → Broadcasts whenever there is a new transaction in the network